### PR TITLE
Add task rollover and auto-copy features for daily notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run tests
+        run: npm test
+
       - name: Package extension
         run: npx @vscode/vsce package --out releases/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Build & Release VSIX
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Package extension
+        run: npx @vscode/vsce package --out releases/
+
+      - name: Commit VSIX to releases/
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add releases/
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore: release $(ls releases/*.vsix | xargs -I{} basename {}) [skip ci]"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@ out
 dist
 node_modules
 .vscode-test/
-*.vsix
 /daily-notes
 01-journal/

--- a/package.json
+++ b/package.json
@@ -77,6 +77,14 @@
       {
         "command": "dailyNotes.generateSampleTodo",
         "title": "dailyNotes: Generate Sample Todo Data"
+      },
+      {
+        "command": "dailyNotes.rolloverAllTasks",
+        "title": "dailyNotes: Roll Over All Tasks in File to Today"
+      },
+      {
+        "command": "dailyNotes.rolloverTaskAtCursor",
+        "title": "dailyNotes: Roll Over Task at Cursor to Today"
       }
     ],
     "configuration": {
@@ -118,7 +126,9 @@
     "onCommand:dailyNotes.openNoteForDate",
     "onCommand:dailyNotes.addTitle",
     "onCommand:dailyNotes.generateTodo",
-    "onCommand:dailyNotes.generateSampleTodo"
+    "onCommand:dailyNotes.generateSampleTodo",
+    "onCommand:dailyNotes.rolloverAllTasks",
+    "onCommand:dailyNotes.rolloverTaskAtCursor"
   ],
   "main": "./out/extension.js",
   "scripts": {

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,147 @@
+# dailynotes-panel — Project Plan
+
+## Vision
+
+A VS Code extension for Obsidian-style daily notes with automatic task tracking. Tasks created anywhere in your vault flow into today's note automatically; uncompleted tasks can be rolled forward; a live sidebar keeps all open tasks visible across the workspace.
+
+---
+
+## Status: What's Built
+
+### Core Infrastructure
+- [x] **Date-formatted daily notes** — supports `yyyy-mm-dd` and `yyyymmdd` filename patterns
+- [x] **Sidebar with three panels** — Daily Notes list, Calendar grid, To Do task tree
+- [x] **Settings** — `dailyNotes.folder`, `dailyNotes.dateFormat`, `dailyNotes.autoSaveEnabled`
+- [x] **Auto-save** — saves dirty files every 10 s; pauses 5 s after typing stops
+
+### Task Metadata & Normalization
+- [x] **Auto-ID assignment** (`id:abc123`) on every task on save
+- [x] **Creation date** (`cd:`) — filename date for daily notes, today for other files
+- [x] **Done date** (`dd:`) — stamped when task is checked `[x]`, removed on uncheck
+- [x] **Due date** (`due:`) — user-supplied; preserved through normalization
+- [x] **Metadata ordering** — tokens always sorted to end of line: `id:` `cd:` `due:` `dd:`
+- [x] **Normalization runs on all .md files**, not just daily notes
+
+### Task Decorators
+- [x] **`~[[target]]`** — "copied/moved TO target"; written on the original/source task
+- [x] **`>[[source]]`** — "originated FROM source"; written on the copy in the destination
+
+### Rollover Commands
+- [x] **`dailyNotes.rolloverAllTasks`** — rolls every uncompleted task in the active file to today
+- [x] **`dailyNotes.rolloverTaskAtCursor`** — rolls just the task on the cursor line
+- [x] **Cross-file propagation** — finds all copies of a task by `id:` and stamps `~[[today]]` on each
+- [x] **Idempotent** — tasks already bearing `~[[today]]` are skipped
+
+### Copy-on-Create (non-daily-note files)
+- [x] **Auto-detect new tasks** on save of any non-daily-note `.md` file
+- [x] **Bootstrap safe** — first save of a file records existing tasks as "pre-existing"; only tasks added after are copied
+- [x] **Copy to today** — new tasks appear in today's `## Tasks` section with `>[[sourceFile]]`
+- [x] **Mark source** — original task gets `~[[today]]` so you can see it was synced
+- [x] **State persisted** — copied task IDs survive VS Code restarts (via `workspaceState`)
+
+### Generate todo.md
+- [x] **`dailyNotes.generateTodo`** — scans all daily notes; groups tasks by `+Project`
+- [x] **Sorted output** — projects alphabetically, tasks by priority within each project
+- [x] **Source links** — each task includes `— [[YYYY-MM-DD]]` link back to its origin
+
+### Other Commands
+- [x] `dailyNotes.refresh` — refresh all sidebar views
+- [x] `dailyNotes.openNote` — open today's note (create if missing)
+- [x] `dailyNotes.openNoteForDate` — open a specific date's note
+- [x] `dailyNotes.addTitle` — insert `# YYYY-MM-DD` heading from filename
+- [x] `dailyNotes.generateSampleTodo` — create demo data for first-time setup
+
+---
+
+## Roadmap: What's Next
+
+### High Priority
+
+- [ ] **Completed task rollover** — option to carry completed tasks forward with a summary section
+- [ ] **Template support** — user-defined template file for new daily notes (instead of hard-coded stub)
+- [ ] **`due:` warnings** — highlight or badge tasks approaching or past their due date in the To Do tree
+- [ ] **Bi-directional sync** — if a task is completed in today's note, mark the corresponding copy in the source file complete too (via shared `id:`)
+- [ ] **Filter by context** — To Do tree filter for `@context` tags (analogous to existing project grouping)
+
+### Medium Priority
+
+- [ ] **Incremental todo.md updates** — avoid re-scanning all files; track which notes changed since last generation
+- [ ] **Archive completed tasks** — command to move all `[x]` tasks from a note to an `archive.md`
+- [ ] **Weekly/monthly rollup** — generate a weekly summary note from daily notes in a date range
+- [ ] **`>[[source]]` navigation** — clicking a `>[[file]]` decorator opens the source file (currently relies on Obsidian-style wiki-link rendering)
+- [ ] **Task search** — quick-pick palette to search all tasks by text across all notes
+
+### Low Priority / Nice-to-have
+
+- [ ] **Recurring tasks** — `recur:daily` / `recur:weekly` metadata token; auto-creates copy in next note
+- [ ] **Pomodoro integration** — start/stop timer from To Do tree; stamps time on task
+- [ ] **Statistics view** — completed vs. open tasks per week, streaks, etc.
+- [ ] **Export** — export tasks to CSV / JSON for external tools
+
+---
+
+## Known Issues & Technical Debt
+
+| Area | Issue |
+|---|---|
+| **Performance** | Todo tree re-scans entire folder on every save — no caching |
+| **Decorators** | `~[[X]]` / `>[[X]]` are plain text; deleting them silently breaks tracking |
+| **Metadata regex** | Global regex state (`lastIndex`) must be manually reset; concurrent use could corrupt results |
+| **Calendar** | Uses `color-mix()` CSS; may fail on very old VS Code/Chromium builds |
+| **Copy-on-create** | `workspaceState` is per-workspace; IDs don't transfer if workspace config changes |
+| **Date validation** | Invalid dates silently dropped; no user feedback |
+| **Sample data** | Running `generateSampleTodo` multiple times appends duplicate blocks |
+| **Architecture** | `extension.ts` is ~1800 lines; candidate for splitting into feature modules |
+
+---
+
+## Conventions Reference
+
+### Task line format
+```
+- [ ] (A) Task description ~[[2026-02-21]] id:abc cd:2026-01-15 due:2026-02-25
+  ^     ^  ^               ^               ^      ^              ^
+  │     │  priority        decorator       id     creation date  due date
+  │     checkbox
+  list marker
+```
+
+### Metadata tokens (auto-normalized, moved to end of line)
+| Token | Auto-set? | Description |
+|---|---|---|
+| `id:` | Yes | 3–10 char random alphanumeric; unique per workspace |
+| `cd:` | Yes | Creation date; filename date for daily notes, today for other files |
+| `dd:` | Yes | Done date; set when `[x]`, removed when unchecked |
+| `due:` | No | User-supplied deadline |
+
+### Decorator convention
+| Decorator | Meaning |
+|---|---|
+| `~[[X]]` | "Copied/moved **to** X" — on the original task |
+| `>[[X]]` | "Originated **from** X" — on the copy in the destination |
+
+### Project & context tags (in task text)
+- `+ProjectName` — groups task under that project in the To Do tree and todo.md
+- `@contextName` — stored on task; filtering not yet implemented
+
+---
+
+## File Map
+
+```
+src/
+  extension.ts    Main extension: providers, commands, event handlers, helpers
+  taskParser.ts   Task parsing, formatting, grouping, sorting
+  utils.ts        Date helpers, file discovery
+
+resources/
+  dailyNotes.svg  Activity bar icon
+
+package.json      Manifest: commands, views, settings, activation events
+tsconfig.json     TypeScript configuration
+jest.config.js    Test configuration
+
+src/__tests__/
+  taskParser.test.ts   Parser unit tests (covering parsing, grouping, formatting)
+  utils.test.ts        Date / file utility unit tests
+```

--- a/skills.md
+++ b/skills.md
@@ -1,0 +1,210 @@
+# dailynotes-panel — Developer Skills Reference
+
+Quick reference for working on this codebase with Claude Code.
+
+---
+
+## Build & Test
+
+```bash
+# Install dependencies
+npm install
+
+# Type-check + compile TypeScript → out/
+npm run compile
+
+# Run unit tests (Jest)
+npm test
+
+# Watch mode (compile on change)
+npm run watch
+```
+
+Always run `npm run compile && npm test` before committing. Both must pass with zero errors.
+
+---
+
+## Project Layout
+
+| Path | Role |
+|---|---|
+| `src/extension.ts` | All VS Code integration: providers, commands, event handlers, normalisation, rollover, copy-on-create |
+| `src/taskParser.ts` | Pure logic: parse task lines, group by project, sort, format todo.md |
+| `src/utils.ts` | Date helpers and daily-note file discovery |
+| `src/__tests__/` | Jest unit tests (taskParser + utils; no VS Code API) |
+| `package.json` | Manifest — commands, views, settings, activation events |
+
+---
+
+## Key Patterns
+
+### Adding a new VS Code command
+
+1. **`package.json`** — register in `contributes.commands` and `activationEvents`:
+   ```json
+   { "command": "dailyNotes.myCommand", "title": "dailyNotes: My Command" }
+   ```
+   ```json
+   "onCommand:dailyNotes.myCommand"
+   ```
+
+2. **`src/extension.ts`** — inside `activate()`, add:
+   ```typescript
+   context.subscriptions.push(
+       vscode.commands.registerCommand('dailyNotes.myCommand', async () => {
+           // implementation
+       })
+   );
+   ```
+
+### Adding a new metadata token
+
+Metadata tokens are stripped from task text and placed at the end of the line by normalization.
+
+1. Extend the regex in **both** files:
+   - `extension.ts`: `META_TOKEN_REGEX = /\b(id|cd|dd|due|NEW):([^\s]+)\b/gi`
+   - `taskParser.ts`: `META_TOKEN = /\b(id|cd|dd|due|NEW):([^\s]+)\b/gi`
+
+2. Add the field to the `Task` interface in `taskParser.ts`.
+
+3. Handle extraction in `stripAndCollectMeta()` (extension.ts) and `parseAndStripMetadata()` (taskParser.ts).
+
+4. Handle serialisation in `buildMetaSuffix()` (extension.ts).
+
+### Accessing configuration
+
+```typescript
+function getNotesFolder(): { folderPath: string; dateFormat: DateFormatOption } | null {
+    // already exists — call this wherever you need the folder path or date format
+}
+```
+
+### Checking if a document is a daily note
+
+```typescript
+isDailyNoteDocument(document, cfg.folderPath, cfg.dateFormat)  // → boolean
+```
+
+### Getting today's date string
+
+```typescript
+formatToday(cfg.dateFormat)  // → "2026-02-21" or "20260221"
+```
+
+### Appending tasks to today's note
+
+```typescript
+await appendTaskLinesToTodayNote(
+    ['- [ ] My new task id:abc cd:2026-02-21'],
+    cfg   // { folderPath, dateFormat }
+);
+// Creates today's note with ## Tasks section if it doesn't exist.
+```
+
+### Applying an edit to a document and saving (with loop-guard)
+
+```typescript
+// Guard first so the triggered onDidSaveTextDocument skips this document.
+normalizingDocuments.add(document.uri.toString());
+try {
+    const edit = new vscode.WorkspaceEdit();
+    edit.replace(document.uri, range, newText);
+    await vscode.workspace.applyEdit(edit);
+    await document.save();
+} finally {
+    normalizingDocuments.delete(document.uri.toString());
+}
+```
+
+---
+
+## Task Line Format
+
+```
+- [ ] (A) Task description ~[[2026-02-21]] id:abc cd:2026-01-15 due:2026-02-25 dd:2026-02-21
+```
+
+The regex that parses this (`TASK_LINE_REGEX` in extension.ts / `taskParser.ts`):
+```
+/^(\s*-\s+\[([ xX])\]\s*)(?:\(([A-Z])\)\s+)?(.+?)\s*$/
+  └── prefix ──────────── └── priority ────┘ └── body ─┘
+```
+
+Metadata tokens recognized (removed from body, moved to suffix):
+- `id:` `cd:` `due:` `dd:`
+
+Decorator tokens (stay in body text, not extracted):
+- `~[[target]]` — task was copied/moved TO target
+- `>[[source]]` — task originated FROM source
+
+---
+
+## Decorator Convention
+
+| Decorator | Meaning | Written on |
+|---|---|---|
+| `~[[X]]` | Copied/moved **to** X | The original / source task |
+| `>[[X]]` | Originated **from** X | The copy in the destination |
+
+Both decorators survive normalization (they are not in `META_TOKEN_REGEX`).
+Both are valid Obsidian wiki links — clickable in any markdown viewer.
+
+---
+
+## State Persisted in workspaceState
+
+| Key | Type | Purpose |
+|---|---|---|
+| `copiedTaskIds` | `string[]` | IDs of tasks already copied to a daily note (copy-on-create) |
+| `initializedNonDailyFiles` | `string[]` | Absolute paths of non-daily files whose first save has been processed |
+
+Helpers: `getCopiedTaskIds()`, `saveCopiedTaskIds()`, `getInitializedNonDailyFiles()`, `saveInitializedNonDailyFiles()`.
+
+---
+
+## Event Handler Summary
+
+| Event | Handler behaviour |
+|---|---|
+| `onWillSaveTextDocument` | Runs `computeTaskNormalizationEdits()` on any `.md` file; edits applied synchronously before save |
+| `onDidSaveTextDocument` | Daily notes: runs `normalizeDailyNoteMetadata()` then `processUpdatedTodosFromDocument()`; non-daily `.md`: runs `copyNewTasksToTodayNote()` |
+| `onDidChangeConfiguration` | Reconfigures autosave and refreshes tree views |
+| `onDidChangeActiveTextEditor` | Saves previous editor if autosave enabled |
+| `onDidChangeTextDocument` | Resets autosave cooldown timer |
+
+`normalizingDocuments: Set<string>` is the loop-guard shared by all handlers. A document URI in this set is skipped by `onDidSaveTextDocument` to prevent infinite save loops.
+
+---
+
+## Adding Tests
+
+Tests live in `src/__tests__/` and use Jest. They must not import `vscode` (no VS Code API available in Jest). Test only the pure-logic layers (`taskParser.ts`, `utils.ts`).
+
+```typescript
+import { parseTaskLine, parseTasksFromContent } from '../taskParser';
+
+test('parses priority', () => {
+    const task = parseTaskLine('- [ ] (A) My task id:abc cd:2026-02-21', 'src', '2026-02-21.md');
+    expect(task?.priority).toBe('A');
+});
+```
+
+---
+
+## Git Workflow
+
+Branch: `claude/add-task-rollover-command-ByP5L`
+
+```bash
+# Before starting work
+git fetch origin claude/add-task-rollover-command-ByP5L
+git pull origin claude/add-task-rollover-command-ByP5L
+
+# After changes
+npm run compile && npm test   # must pass
+git add src/extension.ts src/taskParser.ts ...
+git commit -m "Short description of what and why"
+git push -u origin claude/add-task-rollover-command-ByP5L
+```
+
+Never push to `master` directly.


### PR DESCRIPTION
## Summary
This PR adds two major features for managing tasks across daily notes and other markdown files:

1. **Task Rollover**: Commands to move uncompleted tasks from any file to today's daily note, with decorators tracking the origin and destination.
2. **Auto-Copy New Tasks**: Automatically copies newly created tasks from non-daily-note markdown files to today's note on save.

## Key Changes

- **Task Rollover Helpers**:
  - `insertTaskLinesIntoContent()`: Inserts task lines into the ## Tasks section of a note, creating the section if needed
  - `appendTaskLinesToTodayNote()`: Ensures today's daily note exists and appends task lines to it
  - `updateTaskDecoratorAcrossFiles()`: Propagates decorators across all files that share the same task ID
  - `rolloverTaskLine()`: Rolls over a single uncompleted task with proper decoration tracking

- **Auto-Copy Feature**:
  - `copyNewTasksToTodayNote()`: On first save of a non-daily-note file, records existing task IDs as pre-existing; on subsequent saves, copies newly created uncompleted tasks to today's note
  - Workspace state tracking via `COPIED_TASK_IDS_KEY` and `INITIALIZED_NONDAILY_FILES_KEY` to distinguish pre-existing from newly created tasks
  - Helper functions `getCopiedTaskIds()`, `saveCopiedTaskIds()`, `getInitializedNonDailyFiles()`, `saveInitializedNonDailyFiles()`

- **New Commands**:
  - `dailyNotes.rolloverAllTasks`: Rolls over all uncompleted tasks in the active file to today's note
  - `dailyNotes.rolloverTaskAtCursor`: Rolls over the single task at the cursor to today's note

- **Enhanced Task Normalization**:
  - `computeTaskNormalizationEdits()` now accepts optional `defaultCd` parameter to set creation date for tasks in non-daily-note files (defaults to today's date)
  - Updated `onWillSaveTextDocument` handler to pass today's date as `defaultCd` for non-daily-note markdown files

- **Decorator Convention**:
  - `~[[X]]` = "copied/moved TO X"
  - `>[[X]]` = "originated FROM X"

## Notable Implementation Details

- Task rollover iterates lines from bottom to top to maintain valid line indices after edits
- Auto-copy feature uses workspace state to track which task IDs have been seen, preventing duplicate copies on subsequent saves
- Cross-file task ID propagation ensures consistency when tasks are referenced in multiple files
- Non-daily-note files get today's date as the default creation date (`cd`) for new tasks, providing sensible defaults
- Guards against re-triggering save handlers during normalization using a `normalizingDocuments` set

https://claude.ai/code/session_01Gwe2nxjYjLFHWGH1P24UZw