### PR TITLE
Auto-bump patch version if unchanged in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,14 +32,27 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Bump version if unchanged from main
+        run: |
+          git show HEAD~1:package.json > /tmp/prev_package.json 2>/dev/null || echo '{"version":"0.0.0"}' > /tmp/prev_package.json
+          CURRENT=$(node -p "require('./package.json').version")
+          PREV=$(node -p "require('/tmp/prev_package.json').version")
+          if [ "$CURRENT" = "$PREV" ]; then
+            echo "Version $CURRENT is unchanged from previous commit, bumping patch version..."
+            npm version patch --no-git-tag-version
+            echo "New version: $(node -p "require('./package.json').version")"
+          else
+            echo "Version changed from $PREV to $CURRENT, no auto-bump needed."
+          fi
+
       - name: Package extension
         run: npx @vscode/vsce package --out releases/
 
-      - name: Commit VSIX to releases/
+      - name: Commit release artifacts
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add releases/
+          git add releases/ package.json package-lock.json
           git diff --cached --quiet && echo "No changes to commit" && exit 0
           git commit -m "chore: release $(ls releases/*.vsix | xargs -I{} basename {}) [skip ci]"
           git push


### PR DESCRIPTION
## Summary
Enhanced the release workflow to automatically bump the patch version when the version in `package.json` hasn't been manually updated since the previous commit. This ensures every release has a unique version number.

## Key Changes
- Added automatic patch version bumping step that compares the current version against the previous commit's version
- If versions match, `npm version patch` is run to increment the patch version automatically
- Updated the git commit step to include `package.json` and `package-lock.json` in the release artifacts, ensuring version changes are committed
- Improved commit message clarity by renaming the step from "Commit VSIX to releases/" to "Commit release artifacts"

## Implementation Details
- The version comparison safely handles cases where the previous commit doesn't exist (e.g., first release) by defaulting to version "0.0.0"
- Uses `--no-git-tag-version` flag to prevent automatic git tag creation during version bump
- Includes informative logging to indicate whether auto-bump was triggered or if a manual version change was detected
- Maintains the `[skip ci]` flag in commit messages to prevent recursive workflow triggers

https://claude.ai/code/session_01Fhn6ApxcxRvuoQggpLaDFx